### PR TITLE
fix typo in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,14 +18,14 @@ MangoFix is a DSL which syntax is very similar to Objective-C，MangoFix is also
     BOOL writeResult = NO;
     
     NSURL *scriptUrl = [[NSBundle mainBundle] URLForResource:@"demo" withExtension:@"mg"];
-    NSString *planScriptString = [NSString stringWithContentsOfURL:scriptUrl encoding:NSUTF8StringEncoding error:&outErr];
+    NSString *plainScriptString = [NSString stringWithContentsOfURL:scriptUrl encoding:NSUTF8StringEncoding error:&outErr];
     if (outErr) goto err;
     
     {
         NSURL *publicKeyUrl = [[NSBundle mainBundle] URLForResource:@"public_key.txt" withExtension:nil];
         NSString *publicKey = [NSString stringWithContentsOfURL:publicKeyUrl encoding:NSUTF8StringEncoding error:&outErr];
         if (outErr) goto err;
-        NSString *encryptedScriptString = [MFRSA encryptString:planScriptString publicKey:publicKey];
+        NSString *encryptedScriptString = [MFRSA encryptString:plainScriptString publicKey:publicKey];
         
         NSString * encryptedPath= [(NSString *)[NSSearchPathForDirectoriesInDomains(NSDocumentDirectory, NSUserDomainMask, YES) firstObject] stringByAppendingPathComponent:@"encrypted_demo.mg"];
         NSFileManager *fileManager = [NSFileManager defaultManager];
@@ -417,5 +417,5 @@ class SubMyController:SuperMyController {
    	CFunction<returnType,arg1Type,arg2Type,...> ptr = CFunction("c function name"); // CFunction. 
 	
 
-## Ohter
+## Other
     For more information on MangFix usage, see the MangoFix project unit test.


### PR DESCRIPTION
- `planScriptString => plainScriptString`
- `Ohter => Other`